### PR TITLE
Fixed bug when trying to convert next_funding_time to pd.datetime

### DIFF
--- a/lakeapi/main.py
+++ b/lakeapi/main.py
@@ -213,7 +213,7 @@ def load_data(
         df.rename(columns={"timestamp": "origin_time"}, inplace=True)
         df["origin_time"] = pd.to_datetime(df["origin_time"], unit="ns", cache=True)
     if "next_funding_time" in df.columns:
-        df["next_funding_time"] = pd.to_datetime(df["next_funding_time"], unit="s", cache=True)
+        df.rename(columns={"next_funding_time": "ns_until_next_funding_time"}, inplace=True)
     if table == "trades":
         df.rename(columns={"id": "trade_id"}, inplace=True)
 


### PR DESCRIPTION
next_funding_time was converted to datetime even if it does not contain unix timestamps. Suggested solution is to leave the format as it is and instead rename it to "ns_until_next_funding_time" for clarification.